### PR TITLE
Update discord invite link in homepage

### DIFF
--- a/src/components/home/Hero.js
+++ b/src/components/home/Hero.js
@@ -100,7 +100,7 @@ class Hero extends Component {
                       </a>
                     </Button>
                     <Button discord>
-                      <a href="https://discord.com/invite/sJfvxQW7cd">
+                      <a href="https://discord.gg/wdnKbQbP9d">
                         <FaDiscord /> Join our Discord
                       </a>
                     </Button>


### PR DESCRIPTION
The current discord invite link in homepage is expired. It should be a link that have no expiration. I created a new invite link without expiration and limit of number of invites.

current invite link:
<img width="373" alt="Screenshot 2021-08-26 174057" src="https://user-images.githubusercontent.com/5054560/130949498-a8159f47-d824-4f56-8c8f-3bcf7dd5f75d.png">

how it should have been setup:
<img width="340" alt="Screenshot 2021-08-26 173914" src="https://user-images.githubusercontent.com/5054560/130949551-901e0400-9ec0-4994-ab08-16fcf4d746b9.png">


